### PR TITLE
fix building in CUDA 7.5 Dockerfile

### DIFF
--- a/CUDA/7.5/Dockerfile
+++ b/CUDA/7.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:7.5
+FROM nvidia/cuda:7.5-devel-ubuntu14.04
 MAINTAINER Cristian Baldi "bld.cris.96@gmail.com"
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Fixed building CUDA 7.5 image, because on current version in docker hub I get same error as this issue: https://github.com/crisbal/docker-torch-rnn/issues/1

Read more about performance: https://github.com/crisbal/docker-torch-rnn/pull/13